### PR TITLE
Fix Span Check and multiple whitespace bug in ConLL Conversion

### DIFF
--- a/label_studio_converter/utils.py
+++ b/label_studio_converter/utils.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 import urllib
 import numpy as np
-
+from nltk.tokenize import WhitespaceTokenizer
 from operator import itemgetter
 from PIL import Image
 
@@ -27,30 +27,41 @@ def tokenize(text):
 
 
 def create_tokens_and_tags(text, spans):
-    tokens_and_idx = tokenize(text)
+    #tokens_and_idx = tokenize(text) # This function doesn't work properly if text contains multiple whitespaces...
+    token_index_tuples = [token for token in WhitespaceTokenizer().span_tokenize(text)]
+    tokens_and_idx = [(text[start:end], start) for start, end in token_index_tuples]
     if spans:
         spans = list(sorted(spans, key=itemgetter('start')))
         span = spans.pop(0)
+        span_start = span['start']
+        span_end = span['end']-1
         prefix = 'B-'
         tokens, tags = [], []
         for token, token_start in tokens_and_idx:
             tokens.append(token)
-            token_end = token_start + len(token) - 1
-            if not span or token_end < span['start']:
-                tags.append('O')
-            elif token_start >= span['end']:
-                # this could happen if prev label ends with whitespaces, e.g. "cat " "too"
-                # TODO: it is not right choice to place empty tag here in case when current token is covered by next span  # noqa
-                tags.append('O')
-            else:
-                tags.append(prefix + span['labels'][0])
-                if (span['end'] - 1) > token_end:
-                    prefix = 'I-'
-                elif len(spans):
+            token_end = token_start + len(token) #"- 1" - This substraction is wrong. token already uses the index E.g. "Hello" is 0-4
+            token_start_ind = token_start  #It seems like the token start is too early.. for whichever reason
+
+            #if for some reason end of span is missed.. pop the new span (Which is quite probable due to this method)
+            #Attention it seems like span['end'] is the index of first char afterwards. In case the whitespace is part of the
+            #labell we need to subtract one. Otherwise next token won't trigger the span update.. only the token after next..
+            if token_start_ind > span_end:
+                while spans:
                     span = spans.pop(0)
+                    span_start = span['start']
+                    span_end = span['end'] - 1
                     prefix = 'B-'
-                else:
-                    span = None
+                    if token_start <= span_end:
+                        break
+
+
+            if not span or token_end < span_start:
+                tags.append('O')
+            elif span_start <= token_end and span_end >= token_start_ind:
+                tags.append(prefix + span['labels'][0])
+                prefix = 'I-'
+            else:
+                tags.append('O')
     else:
         tokens = [token for token, _ in tokens_and_idx]
         tags = ['O'] * len(tokens)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=0.24.0
 requests==2.22.0
 Pillow==6.2.1
+nltk==3.5


### PR DESCRIPTION
The logic to check the spans wheter a span overlapped with a token was very messy and wrong. There was even a todo and a message saying one of the ifs was incorrect..


Furthermore the tokenization wasn't able to handle multiple whitespaces until now.

This fixes the following issue:
https://github.com/heartexlabs/label-studio/issues/556

Sorry that I used nltk and this would add another requirement, but with the normal split() method the tokenization would always have problems with multiple whitespaces.