### PR TITLE
Relax dependencies requests and Pillow to allow the whole major versi…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas>=0.24.0
-requests==2.22.0
-Pillow==6.2.1
+requests>=2.22.0,<3
+Pillow>=6.2.1,<7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas>=0.24.0
 requests>=2.22.0,<3
-Pillow>=6.2.1,<7
+Pillow>=7,<8


### PR DESCRIPTION
Relax dependency versions like was done in https://github.com/heartexlabs/label-studio/issues/557

Since this project is a dependency of label-studio, the fix that was implemented for the version of `requests` doesn't take effect until it's fixed here as well -- at least when using poetry.