### PR TITLE
Fixed bug in converter init for brushlabels

### DIFF
--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -198,7 +198,7 @@ class Converter(object):
         if not ('Image' in input_tag_types and ('RectangleLabels' in output_tag_types or
                                                 'PolygonLabels' in output_tag_types)):
             all_formats.remove(Format.COCO.name)
-        if not ('Image' in input_tag_types and 'BrushLabels' in output_tag_types):
+        if not ('Image' in input_tag_types and ('BrushLabels' in output_tag_types or 'brushlabels' in output_tag_types)):
             all_formats.remove(Format.BRUSH_TO_NUMPY.name)
             all_formats.remove(Format.BRUSH_TO_PNG.name)
 


### PR DESCRIPTION
Apparantly the predictions are requiring "brushlabels" as a tag while the export needs "BrushLabels" which are contradicting each other. So when one wants to make use of brush predictions the option to export to png is removed. With adding the "brushlabels" to the options in the output_tag_types it should work