### PR TITLE
add `supercategory` field to COCO categories

### DIFF
--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -475,7 +475,8 @@ class Converter(object):
                     category_name_to_id[category_name] = category_id
                     categories.append({
                         'id': category_id,
-                        'name': category_name
+                        'name': category_name,
+                        'supercategory': category_name
                     })
                 category_id = category_name_to_id[category_name]
 


### PR DESCRIPTION
## Problem:
COCO dataset format requires `supercategory` field for each category: https://cocodataset.org/#format-data

Some detection frameworks such as MMDetection and Detectron expect that field for training/evaluation and COCO json's with missing supercategory field would give error.

## Solution:
By merging this PR, `supercategory` field will be added into COCO categories as the same value of `name` field.