### PR TITLE
fix [issue#64](https://github.com/heartexlabs/label-studio-converter/…

### DIFF
--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -381,7 +381,7 @@ class Converter(object):
                 record['id'] = item['id']
             for name, value in item['output'].items():
                 pretty_value = self._prettify(value)
-                record[name] = pretty_value if isinstance(pretty_value, str) else json.dumps(pretty_value)
+                record[name] = pretty_value if isinstance(pretty_value, str) else json.dumps(pretty_value, ensure_ascii=False)
             record['annotator'] = _get_annotator(item)
             record['annotation_id'] = item['annotation_id']
             record['created_at'] = item['created_at']


### PR DESCRIPTION
fix https://github.com/heartexlabs/label-studio-converter/issues/64.

show unicode more user-friendly in exported csv files.

for example, 

before this PR, a multiple choices with Chinese characters will show in exported csv file like this

```json
{"choices": ["\u91cd\u7f6e\u6635\u79f0", "\u91cd\u7f6e\u5934\u50cf"]}
```

After this PR, it will be showed as below:

```json
{ "choices":["重置昵称","重置头像"]}
```

which is more user friendly.
