### PR TITLE
fixed the brush.decode_from_annotation returning empty dict

### DIFF
--- a/label_studio_converter/brush.py
+++ b/label_studio_converter/brush.py
@@ -100,13 +100,13 @@ def decode_from_annotation(from_name, results):
     for result in results:
         key = 'brushlabels' if result['type'].lower() == 'brushlabels' else \
             ('labels' if result['type'].lower() == 'labels' else None)
-        if key is None or 'rle' not in result:
+        if key is None or 'rle' not in result['value']:
             continue
 
-        rle = result['rle']
+        rle = result['value']['rle']
         width = result['original_width']
         height = result['original_height']
-        labels = result[key] if key in result else ['no_label']
+        labels = result['value'][key] if key in result['value'] else ['no_label']
         name = from_name + '-' + '-'.join(labels)
 
         # result count


### PR DESCRIPTION
This fixes the 
**function brush.decode_from_annotation returns empty dict #81**

The fix consists only in adding the key ['value'] to the *retult* dictionary, because all the used values are nested inside this key.

