### PR TITLE
CONLL: Handle leading whitespace in span

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=0.24.0
 requests>=2.22.0,<3
 Pillow==9.0.1
 nltk==3.6.7
+lxml>=4.8.0

--- a/tests/test_converter_conll.py
+++ b/tests/test_converter_conll.py
@@ -42,3 +42,27 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(tags[3], "B-Person")
         self.assertEqual(tokens[4], "please")
         self.assertEqual(tags[4], "O")
+
+    def test_create_tokens_and_tags_for_full_token(self):
+
+        text = 'We gave Jane Smith the ball.'
+        spans = [{'end': 12, 'labels': ['Person'], 'start': 9, 'text': 'ane'}]
+        tokens,tags = utils.create_tokens_and_tags(text,spans)
+        self.assertEqual(tokens, ['We','gave','Jane','Smith','the','ball.'])
+        self.assertEqual(tags, ['O','O','B-Person','O','O','O'])
+
+    def test_create_tokens_and_tags_with_leading_space(self):
+
+        text = 'We gave Jane Smith the ball.'
+        spans = [{'end': 18, 'labels': ['Person'], 'start': 7, 'text': ' Jane Smith'}]
+        tokens,tags = utils.create_tokens_and_tags(text,spans)
+        self.assertEqual(tokens, ['We','gave','Jane','Smith','the','ball.'])
+        self.assertEqual(tags, ['O','O','B-Person','I-Person','O','O'])
+
+    def test_create_tokens_and_tags_with_trailing_space(self):
+
+        text = 'We gave Jane Smith the ball.'
+        spans = [{'end': 19, 'labels': ['Person'], 'start': 8, 'text': 'Jane Smith '}]
+        tokens,tags = utils.create_tokens_and_tags(text,spans)
+        self.assertEqual(tokens, ['We','gave','Jane','Smith','the','ball.'])
+        self.assertEqual(tags, ['O','O','B-Person','I-Person','O','O'])


### PR DESCRIPTION
If a span has a leading whitespace then the token before it is incorrectly included in the entity.

```
import label_studio_converter.utils as utils
text = 'We gave Jane Smith the ball.'
spans = [{'end': 18, 'labels': ['Person'], 'start': 7, 'text': ' Jane Smith'}]
tokens,tags = utils.create_tokens_and_tags(text,spans)
for x,y in zip(tokens,tags):
    print(f"{x}: {y}")
```

Current behaviour:
```
  We: O
  gave: B-Person
  Jane: I-Person
  Smith: I-Person
  the: O
  ball.: O
```
With this PR:

```
  We: O
  gave: O
  Jane: B-Person
  Smith: I-Person
  the: O
  ball.: O
```

The PR also includes an extra requirement (lxml) which was needed to run the existing tests successfully

```
tests git:(master) ✗ python -m pytest .
============================= test session starts ==============================
platform darwin -- Python 3.9.2, pytest-7.0.1, pluggy-1.0.0
rootdir: *********
collected 2 items / 1 error / 1 selected                                                                            

====================================================== ERRORS =======================================================
__________________________________ ERROR collecting tests/test_converter_conll.py ___________________________________
ImportError while importing test module '******/label-studio-converter/tests/test_converter_conll.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.pyenv/versions/3.9.2/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test_converter_conll.py:2: in <module>
    import label_studio_converter.utils as utils
../label_studio_converter/utils.py:17: in <module>
    from lxml import etree
E   ModuleNotFoundError: No module named 'lxml'
============================================== short test summary info ==============================================
ERROR test_converter_conll.py
```

