### PR TITLE
Fix out-type when is "predictions"

### DIFF
--- a/label_studio_converter/imports/yolo.py
+++ b/label_studio_converter/imports/yolo.py
@@ -126,7 +126,7 @@ def convert_yolo_to_ls(input_dir, out_file,
                     "original_width": image_width,
                     "original_height": image_height
                 }
-                task['annotations'][0]['result'].append(item)
+                task[out_type][0]['result'].append(item)
 
         tasks.append(task)
 


### PR DESCRIPTION
 label-studio-converter import yolo --input two_classes/Ale/ --image-root-url /data/local-files/?d=images/ --out-type "predictions"
INFO:root:Reading YOLO notes and categories from /mnt/d/mutt/vision-api-data/labeling/two_classes/Ale
INFO:root:Found 2 categories
INFO:root:Converting labels from /mnt/d/mutt/vision-api-data/labeling/two_classes/Ale/labels
Traceback (most recent call last):
  File "/home/aleb/.pyenv/versions/3.8.2/bin/label-studio-converter", line 10, in <module>
    sys.exit(main())
  File "/home/aleb/.pyenv/versions/3.8.2/lib/python3.8/site-packages/label_studio_converter/main.py", line 81, in main
    imports(args)
  File "/home/aleb/.pyenv/versions/3.8.2/lib/python3.8/site-packages/label_studio_converter/main.py", line 71, in imports
    import_yolo.convert_yolo_to_ls(input_dir=args.input, out_file=args.output,
  File "/home/aleb/.pyenv/versions/3.8.2/lib/python3.8/site-packages/label_studio_converter/imports/yolo.py", line 129, in convert_yolo_to_ls
    task['annotations'][0]['result'].append(item)
KeyError: 'annotations'