### PR TITLE
fix: Typo in yolo.py

### DIFF
--- a/label_studio_converter/imports/yolo.py
+++ b/label_studio_converter/imports/yolo.py
@@ -37,7 +37,7 @@ def convert_yolo_to_ls(input_dir, out_file,
 
     # generate and save labeling config
     label_config_file = out_file.replace('.json', '') + '.label_config.xml'
-    generate_label_config(categories, {'labels': 'RectangleLabels'}, to_name, from_name, label_config_file)
+    generate_label_config(categories, {'label': 'RectangleLabels'}, to_name, from_name, label_config_file)
 
     # labels, one label per image
     labels_dir = os.path.join(input_dir, 'labels')


### PR DESCRIPTION
- fixed `'labels' ---> 'label'` to match `from_name`.

- alternate : can change from_name to 'labels' if the aforementioned  change breaks `generate_label_config(...)`