### PR TITLE
fix: Bounding boxes with rotation exporter to COCO and YOLO

### DIFF
--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -693,7 +693,7 @@ class Converter(object):
             
             # Label studio saves the position of top left corner after rotation
             x_0 = label_x - radius * (math.cos(math.pi - alpha - beta) - math.cos(math.pi - alpha)) + label_w / 2
-            y_0 = label_y - radius * (math.sin(math.pi - alpha - beta) - math.sin(math.pi - alpha)) + label_h / 2
+            y_0 = label_y + radius * (math.sin(math.pi - alpha - beta) - math.sin(math.pi - alpha)) + label_h / 2
             
             theta_1 = alpha + beta
             theta_2 = math.pi - alpha + beta

--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -652,7 +652,7 @@ class Converter(object):
 
                     if "rectanglelabels" in label or 'labels' in label:
                         x, y, w, h = self.rotated_rectangle(label)
-                        annotations.append([category_id, x, y, w, h])
+                        annotations.append([category_id, (x + w / 2) / 100, (y + h / 2) / 100, w / 100, h / 100])
                     else:
                         raise ValueError(f"Unknown label type {label}")
             with open(label_path, 'w') as f:

--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -490,7 +490,7 @@ class Converter(object):
                 logger.warning('No annotations found for item #' + str(item_idx))
                 continue
           
-            # concatentate results over all tag names
+            # concatenate results over all tag names
             labels = []
             for key in item['output']:
                 labels += item['output'][key]
@@ -524,10 +524,7 @@ class Converter(object):
                 annotation_id = len(annotations)
 
                 if 'rectanglelabels' in label or 'labels' in label:
-                    x = int(label['x'] / 100 * width)
-                    y = int(label['y'] / 100 * height)
-                    w = int(label['width'] / 100 * width)
-                    h = int(label['height'] / 100 * height)
+                    x, y, w, h = self.rotated_rectangle(label)
 
                     annotations.append({
                         'id': annotation_id,
@@ -649,49 +646,7 @@ class Converter(object):
                     category_id = category_name_to_id[category_name]
 
                     if "rectanglelabels" in label or 'labels' in label:
-                        label_x, label_y, label_w, label_h, label_r = (
-                            label["x"],
-                            label["y"],
-                            label["width"],
-                            label["height"],
-                            label["rotation"],
-                        )
-                        if abs(label_r) > 0:
-
-                            aspect = 1
-                            if 'original_width' in label and 'original_height' in label and label['original_height'] != 0:
-                                aspect = label['original_width'] / label['original_height']
-                                label_x = label_x * aspect
-                                label_w = label_w * aspect
-                            
-                            r = math.pi * label_r / 180
-                            sin_r = math.sin(r)
-                            cos_r = math.cos(r)
-                            h_sin_r, h_cos_r = label_h * sin_r, label_h * cos_r
-                            x_top_right = label_x + label_w * cos_r
-                            y_top_right = label_y + label_w * sin_r
-
-                            x_ls = [
-                                label_x,
-                                x_top_right,
-                                x_top_right - h_sin_r,
-                                label_x - h_sin_r,
-                            ]
-                            y_ls = [
-                                label_y,
-                                y_top_right,
-                                y_top_right + h_cos_r,
-                                label_y + h_cos_r,
-                            ]
-                            label_x = max(0, min(x_ls)) / aspect
-                            label_y = max(0, min(y_ls))
-                            label_w = min(100*aspect, max(x_ls))/aspect - label_x
-                            label_h = min(100, max(y_ls)) - label_y
-
-                        x = (label_x + label_w / 2) / 100
-                        y = (label_y + label_h / 2) / 100
-                        w = label_w / 100
-                        h = label_h / 100
+                        x, y, w, h = self.rotated_rectangle(label)
                         annotations.append([category_id, x, y, w, h])
                     else:
                         raise ValueError(f"Unknown label type {label}")
@@ -714,6 +669,52 @@ class Converter(object):
                     'contributor': 'Label Studio'
                 }
             }, fout, indent=2)
+
+    @staticmethod
+    def rotated_rectangle(label):
+        label_x, label_y, label_w, label_h, label_r = (
+            label["x"],
+            label["y"],
+            label["width"],
+            label["height"],
+            label["rotation"],
+        )
+        if abs(label_r) > 0:
+
+            aspect = 1
+            if 'original_width' in label and 'original_height' in label and label['original_height'] != 0:
+                aspect = label['original_width'] / label['original_height']
+                label_x = label_x * aspect
+                label_w = label_w * aspect
+
+            r = math.pi * label_r / 180
+            sin_r = math.sin(r)
+            cos_r = math.cos(r)
+            h_sin_r, h_cos_r = label_h * sin_r, label_h * cos_r
+            x_top_right = label_x + label_w * cos_r
+            y_top_right = label_y + label_w * sin_r
+
+            x_ls = [
+                label_x,
+                x_top_right,
+                x_top_right - h_sin_r,
+                label_x - h_sin_r,
+            ]
+            y_ls = [
+                label_y,
+                y_top_right,
+                y_top_right + h_cos_r,
+                label_y + h_cos_r,
+            ]
+            label_x = max(0, min(x_ls)) / aspect
+            label_y = max(0, min(y_ls))
+            label_w = min(100 * aspect, max(x_ls)) / aspect - label_x
+            label_h = min(100, max(y_ls)) - label_y
+        x = (label_x + label_w / 2) / 100
+        y = (label_y + label_h / 2) / 100
+        w = label_w / 100
+        h = label_h / 100
+        return x, y, w, h
 
     def convert_to_voc(self, input_data, output_dir, output_image_dir=None, is_dir=True):
 


### PR DESCRIPTION
Fixes https://github.com/heartexlabs/label-studio-converter/issues/131

supersedes https://github.com/heartexlabs/label-studio-converter/pull/134

Annotation in Label Studio 1.6.0.rc5 **with rotation**

![annotation](https://user-images.githubusercontent.com/1506457/196599739-95d6450c-ca36-4394-8d60-5a4de76156d7.png)

COCO exporter bundle with Label Studio 1.6.0.rc5 **ignores the rotation**

![annotation16](https://user-images.githubusercontent.com/1506457/196600245-048ed7cb-18fd-4257-953a-64e7adb376d7.png)

COCO exporter patched with https://github.com/heartexlabs/label-studio-converter/pull/134 [after correction](https://github.com/heartexlabs/label-studio-converter/pull/134#discussion_r997680021) is **completely wrong**

![annotation-previous-pr](https://user-images.githubusercontent.com/1506457/196600476-21f47126-04de-4867-afd2-2bc8e18741d7.png)

COCO exporter patched with this PR

![annotation-with-pr](https://user-images.githubusercontent.com/1506457/196600594-c2641455-a225-408e-898a-5a983457d96e.png)

