### PR TITLE
feat: Add support for COCO import of segmentation/polygonlabels

### DIFF
--- a/label_studio_converter/imports/coco.py
+++ b/label_studio_converter/imports/coco.py
@@ -56,8 +56,8 @@ def create_segmentation(annotation, categories, from_name, image_height, image_w
     points = [list(x) for x in zip(*[iter(segmentation)]*2)]
 
     for i in range(len(points)):
-        points[i][0] = points[i][0]/ image_width * 100.0
-        points[i][1] = points[i][1]/ image_height * 100.0
+        points[i][0] = points[i][0] / image_width * 100.0
+        points[i][1] = points[i][1] / image_height * 100.0
 
     item = {
         "id": uuid.uuid4().hex[0:10],


### PR DESCRIPTION
Add support for COCO import of segmentation/polygonlabels.

This enables previous exported projects in COCO format with segmentation to be imported again with intact PolygonLabels.