### PR TITLE
feat: Create independent subdir containing annotations for each labeler when converting from label studio .json to YOLO

### DIFF
--- a/tests/data/test_converter_data/data.json
+++ b/tests/data/test_converter_data/data.json
@@ -1,0 +1,219 @@
+[
+    {
+        "id": 1,
+        "annotations": [
+            {
+                "id": 1,
+                "completed_by": 2,
+                "result": [
+                    {
+                        "original_width": 2800,
+                        "original_height": 2800,
+                        "image_rotation": 0,
+                        "value": {
+                            "x": 37.15846994535519,
+                            "y": 70.67395264116576,
+                            "width": 4.189435336976321,
+                            "height": 4.735883424408015,
+                            "rotation": 0,
+                            "rectanglelabels": [
+                                "parasites"
+                            ]
+                        },
+                        "id": "C7oHaRDVVC",
+                        "from_name": "label",
+                        "to_name": "image",
+                        "type": "rectanglelabels",
+                        "origin": "manual"
+                    },
+                    {
+                        "original_width": 2800,
+                        "original_height": 2800,
+                        "image_rotation": 0,
+                        "value": {
+                            "x": 57.79102500413977,
+                            "y": 62.87464812054977,
+                            "width": 3.808577579069383,
+                            "height": 4.636529226693169,
+                            "rotation": 0,
+                            "rectanglelabels": [
+                                "white"
+                            ]
+                        },
+                        "id": "9GLz8g9skg",
+                        "from_name": "label",
+                        "to_name": "image",
+                        "type": "rectanglelabels",
+                        "origin": "manual"
+                    }
+                ],
+                "was_cancelled": false,
+                "ground_truth": false,
+                "created_at": "2022-12-27T13:36:25.747398Z",
+                "updated_at": "2022-12-27T21:04:40.495704Z",
+                "lead_time": 1235.418,
+                "prediction": {},
+                "result_count": 0,
+                "task": 1,
+                "project": 1,
+                "parent_prediction": null,
+                "parent_annotation": null
+            },
+            {
+                "id": 2,
+                "completed_by": 1,
+                "result": [
+                    {
+                        "original_width": 2800,
+                        "original_height": 2800,
+                        "image_rotation": 0,
+                        "value": {
+                            "x": 37.88706739526412,
+                            "y": 71.76684881602914,
+                            "width": 3.8251366120218573,
+                            "height": 4.553734061930784,
+                            "rotation": 0,
+                            "rectanglelabels": [
+                                "parasites"
+                            ]
+                        },
+                        "id": "ipBS_GBGZp",
+                        "from_name": "label",
+                        "to_name": "image",
+                        "type": "rectanglelabels",
+                        "origin": "manual"
+                    },
+                    {
+                        "original_width": 2800,
+                        "original_height": 2800,
+                        "image_rotation": 0,
+                        "value": {
+                            "x": 49.18032786885246,
+                            "y": 23.13296903460838,
+                            "width": 5.2823315118397085,
+                            "height": 4.007285974499089,
+                            "rotation": 0,
+                            "rectanglelabels": [
+                                "white"
+                            ]
+                        },
+                        "id": "QtdGMXo-M0",
+                        "from_name": "label",
+                        "to_name": "image",
+                        "type": "rectanglelabels",
+                        "origin": "manual"
+                    }
+                ],
+                "was_cancelled": false,
+                "ground_truth": false,
+                "created_at": "2022-12-27T13:37:15.043317Z",
+                "updated_at": "2022-12-27T21:05:03.127871Z",
+                "lead_time": 85.444,
+                "prediction": {},
+                "result_count": 0,
+                "task": 1,
+                "project": 1,
+                "parent_prediction": null,
+                "parent_annotation": null
+            }
+        ],
+        "drafts": [],
+        "predictions": [],
+        "data": {
+            "image": "/image1"
+        },
+        "meta": {},
+        "created_at": "2022-12-27T12:06:58.502299Z",
+        "updated_at": "2022-12-27T21:05:03.168883Z",
+        "inner_id": 1,
+        "total_annotations": 2,
+        "cancelled_annotations": 0,
+        "total_predictions": 0,
+        "comment_count": 0,
+        "unresolved_comment_count": 0,
+        "last_comment_updated_at": null,
+        "project": 1,
+        "updated_by": 1,
+        "comment_authors": []
+    },
+    {
+        "id": 2,
+        "annotations": [
+            {
+                "id": 3,
+                "completed_by": 1,
+                "result": [
+                    {
+                        "original_width": 2800,
+                        "original_height": 2800,
+                        "image_rotation": 0,
+                        "value": {
+                            "x": 19.672131147540984,
+                            "y": 49.72677595628415,
+                            "width": 3.278688524590164,
+                            "height": 2.914389799635701,
+                            "rotation": 0,
+                            "rectanglelabels": [
+                                "white"
+                            ]
+                        },
+                        "id": "1o3pxwJAxl",
+                        "from_name": "label",
+                        "to_name": "image",
+                        "type": "rectanglelabels",
+                        "origin": "manual"
+                    },
+                    {
+                        "original_width": 2800,
+                        "original_height": 2800,
+                        "image_rotation": 0,
+                        "value": {
+                            "x": 61.74863387978142,
+                            "y": 37.15846994535519,
+                            "width": 2.5500910746812386,
+                            "height": 4.371584699453552,
+                            "rotation": 0,
+                            "rectanglelabels": [
+                                "white"
+                            ]
+                        },
+                        "id": "-GoXZ7Oj8k",
+                        "from_name": "label",
+                        "to_name": "image",
+                        "type": "rectanglelabels",
+                        "origin": "manual"
+                    }
+                ],
+                "was_cancelled": false,
+                "ground_truth": false,
+                "created_at": "2022-12-27T17:20:52.822626Z",
+                "updated_at": "2022-12-27T21:05:25.940182Z",
+                "lead_time": 5.651999999999999,
+                "prediction": {},
+                "result_count": 0,
+                "task": 2,
+                "project": 1,
+                "parent_prediction": null,
+                "parent_annotation": null
+            }
+        ],
+        "drafts": [],
+        "predictions": [],
+        "data": {
+            "image": "/image2"
+        },
+        "meta": {},
+        "created_at": "2022-12-27T12:06:58.511973Z",
+        "updated_at": "2022-12-27T21:05:25.980897Z",
+        "inner_id": 2,
+        "total_annotations": 1,
+        "cancelled_annotations": 0,
+        "total_predictions": 0,
+        "comment_count": 0,
+        "unresolved_comment_count": 0,
+        "last_comment_updated_at": null,
+        "project": 1,
+        "updated_by": 1,
+        "comment_authors": []
+    }
+]

--- a/tests/data/test_converter_data/label_config.xml
+++ b/tests/data/test_converter_data/label_config.xml
@@ -1,0 +1,8 @@
+<View>
+  <Image name="image" value="$image"/>
+  <Header value="RectangleLabels"/>
+  <RectangleLabels name="label" toName="image">
+    <Label value="parasites" background="rgba(218, 1, 238, 1)"/>
+    <Label value="white" background="rgba(0, 255, 0, 1)"/>
+  </RectangleLabels>
+</View>

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -4,11 +4,10 @@ import pytest
 import tempfile
 import shutil
 
-# Define path
-TEST_DATA_PATH = os.path.join("data","test_converter_data")
-INPUT_JSON_PATH = os.path.join(TEST_DATA_PATH, "data.json")
-LABEL_CONFIG_PATH = os.path.join(TEST_DATA_PATH, "label_config.xml")
-
+BASE_DIR = os.path.dirname(__file__)
+TEST_DATA_PATH = os.path.join(BASE_DIR, "data","test_converter_data")
+INPUT_JSON_PATH = os.path.join(BASE_DIR, TEST_DATA_PATH, "data.json")
+LABEL_CONFIG_PATH = os.path.join(BASE_DIR, TEST_DATA_PATH, "label_config.xml")
 
 def check_equal_list_of_strings(list1, list2):
     # Check that both lists are not empty
@@ -49,6 +48,11 @@ def create_temp_folder():
 
 
 def test_convert_to_yolo(create_temp_folder):
+    """_summary_
+
+    Args:
+        create_temp_folder (_type_): _description_
+    """
     
     # Generates a temporary folder and return the absolute path
     # The temporary folder contains all the data generate by the following function

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -5,28 +5,30 @@ import tempfile
 import shutil
 
 BASE_DIR = os.path.dirname(__file__)
-TEST_DATA_PATH = os.path.join(BASE_DIR, "data","test_converter_data")
+TEST_DATA_PATH = os.path.join(BASE_DIR, "data", "test_converter_data")
 INPUT_JSON_PATH = os.path.join(BASE_DIR, TEST_DATA_PATH, "data.json")
 LABEL_CONFIG_PATH = os.path.join(BASE_DIR, TEST_DATA_PATH, "label_config.xml")
+
 
 def check_equal_list_of_strings(list1, list2):
     # Check that both lists are not empty
     if not list1 or not list2:
         return False
-    
+
     list1.sort()
     list2.sort()
-    
+
     # Check that the lists have the same length
     if len(list1) != len(list2):
         return False
-    
+
     # Check that the elements of the lists are equal
     for i in range(len(list1)):
         if list1[i] != list2[i]:
             return False
-    
+
     return True
+
 
 def get_os_walk(root_path):
     list_file_paths = []
@@ -35,51 +37,57 @@ def get_os_walk(root_path):
             list_file_paths += [os.path.join(root, f)]
     return list_file_paths
 
+
 @pytest.fixture
 def create_temp_folder():
     # Create a temporary folder
     temp_dir = tempfile.mkdtemp()
-    
+
     # Yield the temporary folder
     yield temp_dir
-    
+
     # Remove the temporary folder after the test
     shutil.rmtree(temp_dir)
 
 
 def test_convert_to_yolo(create_temp_folder):
     """Check converstion label_studio json exported file to yolo with multiple labelers"""
-    
+
     # Generates a temporary folder and return the absolute path
     # The temporary folder contains all the data generate by the following function
     # For debugging replace create_temp_folder with "./tmp"
-    tmp_folder =  create_temp_folder
-    
+    tmp_folder = create_temp_folder
+
     output_dir = tmp_folder
-    output_image_dir =  os.path.join(output_dir,"tmp_image")
-    output_label_dir = os.path.join(output_dir,"tmp_label")
+    output_image_dir = os.path.join(output_dir, "tmp_image")
+    output_label_dir = os.path.join(output_dir, "tmp_label")
     project_dir = "."
 
     converter = Converter(LABEL_CONFIG_PATH, project_dir)
-    converter.convert_to_yolo(INPUT_JSON_PATH,
-                            output_dir,
-                            output_image_dir=output_image_dir, 
-                            output_label_dir=output_label_dir,
-                            is_dir=False,
-                            split_labelers=True,
-                            )
+    converter.convert_to_yolo(
+        INPUT_JSON_PATH,
+        output_dir,
+        output_image_dir=output_image_dir,
+        output_label_dir=output_label_dir,
+        is_dir=False,
+        split_labelers=True,
+    )
 
     abs_path_label_dir = os.path.abspath(output_label_dir)
     expected_paths = [
-            os.path.join(abs_path_label_dir,  "1","image1.txt"),
-            os.path.join(abs_path_label_dir,  "1","image2.txt"),
-            os.path.join(abs_path_label_dir,  "2","image1.txt"),
-            ]
+        os.path.join(abs_path_label_dir, "1", "image1.txt"),
+        os.path.join(abs_path_label_dir, "1", "image2.txt"),
+        os.path.join(abs_path_label_dir, "2", "image1.txt"),
+    ]
     generated_paths = get_os_walk(abs_path_label_dir)
     # Check all files and subfolders have been generated.
-    assert check_equal_list_of_strings(expected_paths,generated_paths), f"Generated file: \n  {generated_paths} \n does not match expected ones: \n {expected_paths}"
+    assert check_equal_list_of_strings(
+        expected_paths, generated_paths
+    ), f"Generated file: \n  {generated_paths} \n does not match expected ones: \n {expected_paths}"
     # Check all the annotations have been converted to yolo
     for file in expected_paths:
         with open(file) as f:
             lines = f.readlines()
-            assert len(lines) == 2, f"Expect different number of annotations in file {file}."
+            assert (
+                len(lines) == 2
+            ), f"Expect different number of annotations in file {file}."

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,79 @@
+from label_studio_converter import Converter
+import os
+import pytest
+import tempfile
+import shutil
+
+# Define path
+TEST_DATA_PATH = os.path.join("data","test_converter_data")
+INPUT_JSON_PATH = os.path.join(TEST_DATA_PATH, "data.json")
+LABEL_CONFIG_PATH = os.path.join(TEST_DATA_PATH, "label_config.xml")
+
+
+def check_equal_list_of_strings(list1, list2):
+    # Check that both lists are not empty
+    if not list1 or not list2:
+        return False
+    
+    list1.sort()
+    list2.sort()
+    
+    # Check that the lists have the same length
+    if len(list1) != len(list2):
+        return False
+    
+    # Check that the elements of the lists are equal
+    for i in range(len(list1)):
+        if list1[i] != list2[i]:
+            return False
+    
+    return True
+
+def get_os_walk(root_path):
+    list_file_paths = []
+    for root, dirs, files in os.walk(root_path):
+        for f in files:
+            list_file_paths += [os.path.join(root, f)]
+    return list_file_paths
+
+@pytest.fixture
+def create_temp_folder():
+    # Create a temporary folder
+    temp_dir = tempfile.mkdtemp()
+    
+    # Yield the temporary folder
+    yield temp_dir
+    
+    # Remove the temporary folder after the test
+    shutil.rmtree(temp_dir)
+
+
+def test_convert_to_yolo(create_temp_folder):
+    
+    # Generates a temporary folder and return the absolute path
+    # The temporary folder contains all the data generate by the following function
+    # For debugging replace create_temp_folder with "./tmp"
+    tmp_folder =  create_temp_folder
+    
+    output_dir = tmp_folder
+    output_image_dir =  os.path.join(output_dir,"tmp_image")
+    output_label_dir = os.path.join(output_dir,"tmp_label")
+    project_dir = "."
+
+    converter = Converter(LABEL_CONFIG_PATH, project_dir)
+    converter.convert_to_yolo(INPUT_JSON_PATH,
+                            output_dir,
+                            output_image_dir=output_image_dir, 
+                            output_label_dir=output_label_dir,
+                            is_dir=False,
+                            split_labelers=True,
+                            )
+
+    abs_path_label_dir = os.path.abspath(output_label_dir)
+    expected_paths = [
+            os.path.join(abs_path_label_dir,  "1","image1.txt"),
+            os.path.join(abs_path_label_dir,  "1","image2.txt"),
+            os.path.join(abs_path_label_dir,  "2","image1.txt"),
+            ]
+    generated_paths = get_os_walk(abs_path_label_dir)
+    assert check_equal_list_of_strings(expected_paths,generated_paths), f"Generated file: \n  {generated_paths} \n does not match expected ones: \n {expected_paths}"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -48,11 +48,7 @@ def create_temp_folder():
 
 
 def test_convert_to_yolo(create_temp_folder):
-    """_summary_
-
-    Args:
-        create_temp_folder (_type_): _description_
-    """
+    """Check converstion label_studio json exported file to yolo with multiple labelers"""
     
     # Generates a temporary folder and return the absolute path
     # The temporary folder contains all the data generate by the following function
@@ -80,4 +76,10 @@ def test_convert_to_yolo(create_temp_folder):
             os.path.join(abs_path_label_dir,  "2","image1.txt"),
             ]
     generated_paths = get_os_walk(abs_path_label_dir)
+    # Check all files and subfolders have been generated.
     assert check_equal_list_of_strings(expected_paths,generated_paths), f"Generated file: \n  {generated_paths} \n does not match expected ones: \n {expected_paths}"
+    # Check all the annotations have been converted to yolo
+    for file in expected_paths:
+        with open(file) as f:
+            lines = f.readlines()
+            assert len(lines) == 2, f"Expect different number of annotations in file {file}."


### PR DESCRIPTION
# Use case:

- Object detection task.
- Exporting to YOLO from label studio.
- Convert exported label studio .json file to YOLO format

# Issue:
In case different users performed different annotation of the same image, when exporting the results to label studio standard `.json`, the different labels are distinguished by `compled_by=<user_id>`  field (ex. [here](https://github.com/heartexlabs/label-studio-converter/compare/master...francescocarpanese:label-studio-converter:master#diff-0c20f6c802d0be926ef92e91b2c872d41034e4755c58658f18da82a2054097efR7) ).

In the current master, when converting the exported `.json` to YOLO, with  `convert_to_yolo` from [label_studio_converter/converter.py](https://github.com/heartexlabs/label-studio-converter/compare/master...francescocarpanese:label-studio-converter:master#diff-322ce95b5aa5f02fb330c7f62be1ea0066c01829b564db0644872e09338a3ddf), a single `.txt` file containing the annotation for a given `image` is created. 

However, the current looping logic overwrites the `.txt` for each user and, as a result, the final `.txt` file contains the annotation  only one user (the annotations which appear at last in the .json) file. 

Moreover the information regarding the user that performed the annotation is lost in YOLO format.

# Implemented solution: 
The function [convert_to_yolo](https://github.com/heartexlabs/label-studio-converter/compare/master...francescocarpanese:label-studio-converter:master#diff-322ce95b5aa5f02fb330c7f62be1ea0066c01829b564db0644872e09338a3ddfR608) takes now an optional argument `split_labelers`. If `true`, it generates dedicated subfolders for each use, containing the annotation of the user.

 By default `split_labelers` is set to false preserving the former behavior.

# Test:
A test is implemented for the use case, converting a json file created from label-studio with multiple labelers for the same image, which servers also as an example for documentation.
